### PR TITLE
Travic CI update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 sudo: false
 language: node_js
 node_js:
-  - '4.2.1'
-install:
-  - npm install
-script:
-  - npm test
+  - 'stable'

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
-    "unmockedModulePathPatterns": ["react"],
+    "unmockedModulePathPatterns": [
+      "react"
+    ],
     "testPathDirs": [
       "./app/"
     ]
@@ -18,6 +20,7 @@
     "babel-jest": "^5.3.0",
     "babel-loader": "^5.3.2",
     "eslint-plugin-react": "^3.6.2",
+    "jest-cli": "^0.5.10",
     "jsdom": "^7.0.1",
     "react-addons-test-utils": "^0.14.0",
     "webpack": "^1.12.2",


### PR DESCRIPTION
Travis CI po defaultu zove `npm install` i `npm test`, pa to ne treba. A verziju sam stavio `stable`, to je zadnja stabilna. Može?
